### PR TITLE
Add rewards estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # taco-rewards-bot
 A bot that periodically transfers the ongoing TACo rewards to TACoApp contract to be distributed
+
+This should be executed periodically with a
+[`rewardDuration`](https://github.com/nucypher/nucypher-contracts/blob/main/contracts/contracts/TACoApplication.sol#L205)
+frequency.
+
+### Running fork for development purposes
+
+.env file:
+
+```
+WEB3_INFURA_PROJECT_ID=deaxxxxxxxxxxxxxxxxxxxxxxxxxxe1c
+```
+
+```
+export APE_ACCOUNTS_rewards-distributor_PASSPHRASE=xxxxxx
+ape run rewards_bot --account rewards-distributor --network ethereum:sepolia-fork:foundry
+```

--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -3,6 +3,10 @@ name: taco-rewards-bot
 plugins:
   - name: solidity
 
+ethereum:
+  sepolia:
+    default_provider: infura
+
 dependencies:
   - name: nucypher-contracts
     github: nucypher/nucypher-contracts

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pre-commit==3.7.1
 eth-ape~=0.7.0
 ape-solidity~=0.7.0
 ape-infura~=0.7.0
+ape-foundry~=0.7.0

--- a/scripts/rewards_bot.py
+++ b/scripts/rewards_bot.py
@@ -38,5 +38,4 @@ def cli(account, apy):
     # TODO: check error
     taco_application.pushReward(rewards_to_be_pushed, sender=account)
 
-    # TODO: use logger instead of print
     logger.info("Rewards pushed: ", int(rewards_to_be_pushed))

--- a/scripts/rewards_bot.py
+++ b/scripts/rewards_bot.py
@@ -2,6 +2,7 @@ import click
 import time
 from ape import project
 from ape.cli import ConnectedProviderCommand, account_option
+from ape.logging import logger
 
 YEAR_IN_SECONDS = 31536000
 TACo_APP_ADDRESS = "0x329bc9Df0e45f360583374726ccaFF003264a136"
@@ -38,4 +39,4 @@ def cli(account, apy):
     taco_application.pushReward(rewards_to_be_pushed, sender=account)
 
     # TODO: use logger instead of print
-    print(int(rewards_to_be_pushed))
+    logger.info("Rewards pushed: ", int(rewards_to_be_pushed))


### PR DESCRIPTION
The rewards to be pushed (transferred from bot to TACoApp contract) must be calculated/estimated.

As a first iteration and considering that this is intended to be used in TACo testnet, the rewards is being calculated following this expression:

```
rewardsToBePushed = AuthorizedOverall * APY * (secondsElapsedSinceLastPush / 1 yearInSeconds)
```

where:

- AuthorizedOverall is the sum of the T authorizations of all stakes and can be queried as a public variable from TACoApp contract.
- APY is the Annual Percent Yield for TACo staking rewards. Currently, 3.75%.

This closes #3 
